### PR TITLE
Add missing common powsybl-ws-commons dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,10 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-stream</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-ws-commons</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -112,16 +112,16 @@
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-stream</artifactId>
+        </dependency>
 
         <!-- Runtime dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
             <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-stream</artifactId>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>


### PR DESCRIPTION
Missing powsybl-ws-commons leads to missing common spring boot configuration in case-import-server. 
This PR adds the dependency so that the case import server accepts upload of files larger than the default max size.