### PR TITLE
Make target import directory configurable per case origin

### DIFF
--- a/src/main/java/org/gridsuite/caseimport/server/CaseImportApplication.java
+++ b/src/main/java/org/gridsuite/caseimport/server/CaseImportApplication.java
@@ -8,12 +8,14 @@ package org.gridsuite.caseimport.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 /**
  * @author Abdelsalem HEDHILI <abdelsalem.hedhili at rte-france.com>
  */
 @SuppressWarnings("checkstyle:HideUtilityClassConstructor")
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class CaseImportApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/gridsuite/caseimport/server/CaseImportConfig.java
+++ b/src/main/java/org/gridsuite/caseimport/server/CaseImportConfig.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.gridsuite.caseimport.server;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+
+import java.util.Map;
+
+/**
+ * @author Charaf EL MHARI <charaf.elmhari at rte-france.com>
+ */
+
+@Setter
+@Getter
+@ConfigurationPropertiesScan
+@ConfigurationProperties("case-import-server")
+public class CaseImportConfig {
+    private Map<String, String> targetDirectories;
+}

--- a/src/main/java/org/gridsuite/caseimport/server/CaseImportConfig.java
+++ b/src/main/java/org/gridsuite/caseimport/server/CaseImportConfig.java
@@ -7,10 +7,10 @@
 
 package org.gridsuite.caseimport.server;
 
+import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 import java.util.Map;
 
@@ -20,8 +20,15 @@ import java.util.Map;
 
 @Setter
 @Getter
-@ConfigurationPropertiesScan
 @ConfigurationProperties("case-import-server")
 public class CaseImportConfig {
     private Map<String, String> targetDirectories;
+    private static final String DEFAULT_IMPORT_DIR_KEY = "default";
+    private static final String DEFAULT_IMPORT_DIR = "Automatic_cases_import";
+
+    @PostConstruct
+    public void addDefaultTarget() {
+        targetDirectories.putIfAbsent(DEFAULT_IMPORT_DIR_KEY, DEFAULT_IMPORT_DIR);
+    }
+
 }

--- a/src/main/java/org/gridsuite/caseimport/server/CaseImportController.java
+++ b/src/main/java/org/gridsuite/caseimport/server/CaseImportController.java
@@ -11,8 +11,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -29,17 +29,23 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @ComponentScan(basePackageClasses = CaseImportService.class)
 public class CaseImportController {
 
-    @Autowired
-    private CaseImportService caseImportService;
+    private final CaseImportService caseImportService;
+
+    public CaseImportController(CaseImportService caseImportService) {
+        this.caseImportService = caseImportService;
+    }
 
     @PostMapping(value = "/cases", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = APPLICATION_JSON_VALUE)
     @Operation(summary = "Import a case in the parametrized directory")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The case is imported"),
         @ApiResponse(responseCode = "400", description = "Invalid case file"),
-        @ApiResponse(responseCode = "422", description = "File with wrong extension")})
-    public ResponseEntity<Void> importCase(@Parameter(description = "case file") @RequestPart("caseFile") MultipartFile caseFile,
+        @ApiResponse(responseCode = "422", description = "File with wrong extension"),
+        @ApiResponse(responseCode = "201", description = "Case created successfully")})
+    public ResponseEntity<ImportedCase> importCase(@Parameter(description = "case file") @RequestPart("caseFile") MultipartFile caseFile,
+                                           @Parameter(description = "origin of case file") @RequestParam(required = false) String caseFileSource,
                                            @RequestHeader("userId") String userId) {
-        caseImportService.importCaseInDirectory(caseFile, userId);
-        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).build();
+        ImportedCase importedCase = caseImportService.importCaseInDirectory(caseFile, caseFileSource, userId);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(importedCase);
     }
 }

--- a/src/main/java/org/gridsuite/caseimport/server/CaseImportController.java
+++ b/src/main/java/org/gridsuite/caseimport/server/CaseImportController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.gridsuite.caseimport.server.dto.ImportedCase;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -42,8 +43,8 @@ public class CaseImportController {
         @ApiResponse(responseCode = "422", description = "File with wrong extension"),
         @ApiResponse(responseCode = "201", description = "Case created successfully")})
     public ResponseEntity<ImportedCase> importCase(@Parameter(description = "case file") @RequestPart("caseFile") MultipartFile caseFile,
-                                           @Parameter(description = "origin of case file") @RequestParam(required = false) String caseFileSource,
-                                           @RequestHeader("userId") String userId) {
+                                                   @Parameter(description = "origin of case file") @RequestParam(defaultValue = "default", required = false) String caseFileSource,
+                                                   @RequestHeader("userId") String userId) {
         ImportedCase importedCase = caseImportService.importCaseInDirectory(caseFile, caseFileSource, userId);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(importedCase);

--- a/src/main/java/org/gridsuite/caseimport/server/CaseImportException.java
+++ b/src/main/java/org/gridsuite/caseimport/server/CaseImportException.java
@@ -16,6 +16,7 @@ public class CaseImportException extends RuntimeException {
     public enum Type {
         IMPORT_CASE_FAILED,
         INCORRECT_CASE_FILE,
+        UNKNOWN_CASE_SOURCE,
         REMOTE_ERROR,
     }
 

--- a/src/main/java/org/gridsuite/caseimport/server/CaseImportService.java
+++ b/src/main/java/org/gridsuite/caseimport/server/CaseImportService.java
@@ -45,7 +45,7 @@ class CaseImportService {
         }
         String targetDirectory = caseImportConfig.getTargetDirectories().get(caseOrigin);
         if (targetDirectory == null) {
-            throw new CaseImportException(UNKNOWN_CASE_SOURCE, "{\"message\": Unknown case source " + caseOrigin + "\"}");
+            throw new CaseImportException(UNKNOWN_CASE_SOURCE, "Unknown case origin " + caseOrigin);
         }
         return targetDirectory;
     }

--- a/src/main/java/org/gridsuite/caseimport/server/CaseImportService.java
+++ b/src/main/java/org/gridsuite/caseimport/server/CaseImportService.java
@@ -14,14 +14,18 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;
 
+import static org.gridsuite.caseimport.server.CaseImportException.Type.UNKNOWN_CASE_SOURCE;
+
 /**
  * @author Abdelsalem HEDHILI <abdelsalem.hedhili at rte-france.com>
  */
 @Service
 class CaseImportService {
 
-    @Value("${target-directory-name:automatic cases}")
+    @Value("${case-import-server.target-directories.default:automatic cases}")
     private String directoryName;
+
+    private final CaseImportConfig caseImportConfig;
 
     private final DirectoryService directoryService;
 
@@ -29,14 +33,32 @@ class CaseImportService {
 
     static final String CASE = "CASE";
 
-    public CaseImportService(CaseService caseService, DirectoryService directoryService) {
+    public CaseImportService(CaseService caseService, DirectoryService directoryService, CaseImportConfig caseImportConfig) {
         this.caseService = caseService;
         this.directoryService = directoryService;
+        this.caseImportConfig = caseImportConfig;
     }
 
-    void importCaseInDirectory(MultipartFile caseFile, String userId) {
+    private String getTargetDirectory(String caseOrigin) {
+        if (caseOrigin == null || caseOrigin.isEmpty()) {
+            return directoryName;
+        }
+        String targetDirectory = caseImportConfig.getTargetDirectories().get(caseOrigin);
+        if (targetDirectory == null) {
+            throw new CaseImportException(UNKNOWN_CASE_SOURCE, "{\"message\": Unknown case source " + caseOrigin + "\"}");
+        }
+        return targetDirectory;
+    }
+
+    ImportedCase importCaseInDirectory(MultipartFile caseFile, String caseOrigin, String userId) {
+        String targetDirectory = getTargetDirectory(caseOrigin);
         UUID caseUuid = caseService.importCase(caseFile);
         var caseElementAttributes = new ElementAttributes(caseUuid, caseFile.getOriginalFilename(), CASE, new AccessRightsAttributes(false), userId, 0L, null);
-        directoryService.createElementInDirectory(caseElementAttributes, directoryName, userId);
+        directoryService.createElementInDirectory(caseElementAttributes, targetDirectory, userId);
+        ImportedCase importedCase = new ImportedCase();
+        importedCase.setCaseName(caseElementAttributes.getElementName());
+        importedCase.setCaseUuid(caseElementAttributes.getElementUuid());
+        importedCase.setParentDirectory(targetDirectory);
+        return importedCase;
     }
 }

--- a/src/main/java/org/gridsuite/caseimport/server/CaseImportService.java
+++ b/src/main/java/org/gridsuite/caseimport/server/CaseImportService.java
@@ -8,7 +8,7 @@ package org.gridsuite.caseimport.server;
 
 import org.gridsuite.caseimport.server.dto.AccessRightsAttributes;
 import org.gridsuite.caseimport.server.dto.ElementAttributes;
-import org.springframework.beans.factory.annotation.Value;
+import org.gridsuite.caseimport.server.dto.ImportedCase;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -21,9 +21,6 @@ import static org.gridsuite.caseimport.server.CaseImportException.Type.UNKNOWN_C
  */
 @Service
 class CaseImportService {
-
-    @Value("${case-import-server.target-directories.default:automatic cases}")
-    private String directoryName;
 
     private final CaseImportConfig caseImportConfig;
 
@@ -40,9 +37,6 @@ class CaseImportService {
     }
 
     private String getTargetDirectory(String caseOrigin) {
-        if (caseOrigin == null || caseOrigin.isEmpty()) {
-            return directoryName;
-        }
         String targetDirectory = caseImportConfig.getTargetDirectories().get(caseOrigin);
         if (targetDirectory == null) {
             throw new CaseImportException(UNKNOWN_CASE_SOURCE, "Unknown case origin " + caseOrigin);

--- a/src/main/java/org/gridsuite/caseimport/server/CaseService.java
+++ b/src/main/java/org/gridsuite/caseimport/server/CaseService.java
@@ -73,7 +73,7 @@ public class CaseService {
         if (!"".equals(response)) {
             throw new CaseImportException(CaseImportException.Type.REMOTE_ERROR, response);
         } else {
-            throw new CaseImportException(CaseImportException.Type.REMOTE_ERROR, "{\"message\": " + statusCode + "\"}");
+            throw new CaseImportException(CaseImportException.Type.REMOTE_ERROR, statusCode.toString());
         }
     }
 }

--- a/src/main/java/org/gridsuite/caseimport/server/CaseService.java
+++ b/src/main/java/org/gridsuite/caseimport/server/CaseService.java
@@ -16,11 +16,9 @@ import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
 import java.util.Objects;
 import java.util.UUID;
 
-import static org.gridsuite.caseimport.server.CaseImportException.Type.IMPORT_CASE_FAILED;
 import static org.gridsuite.caseimport.server.CaseImportException.Type.INCORRECT_CASE_FILE;
 
 
@@ -51,14 +49,12 @@ public class CaseService {
         UUID caseUuid;
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
-        try {
-            if (multipartFile != null) {
-                multipartBodyBuilder.part("file", multipartFile.getBytes())
-                        .filename(Objects.requireNonNull(multipartFile.getOriginalFilename()));
-            }
-        } catch (IOException e) {
-            throw new CaseImportException(IMPORT_CASE_FAILED);
+
+        if (multipartFile != null) {
+            multipartBodyBuilder.part("file", multipartFile.getResource())
+                    .filename(Objects.requireNonNull(multipartFile.getOriginalFilename()));
         }
+
         HttpEntity<MultiValueMap<String, HttpEntity<?>>> request = new HttpEntity<>(
                 multipartBodyBuilder.build(), headers);
         try {

--- a/src/main/java/org/gridsuite/caseimport/server/ImportedCase.java
+++ b/src/main/java/org/gridsuite/caseimport/server/ImportedCase.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.caseimport.server;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+/**
+ * @author Charaf EL MHARI <charaf.elmhari at rte-france.com>
+ */
+
+@Setter
+@Getter
+public class ImportedCase {
+    private UUID caseUuid;
+    private String caseName;
+    private String parentDirectory;
+}

--- a/src/main/java/org/gridsuite/caseimport/server/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/org/gridsuite/caseimport/server/RestResponseEntityExceptionHandler.java
@@ -27,20 +27,18 @@ public class RestResponseEntityExceptionHandler {
         if (LOGGER.isErrorEnabled()) {
             LOGGER.error(exception.getMessage(), exception);
         }
-        switch (exception.getType()) {
-            case REMOTE_ERROR:
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exception.getMessage());
-            case INCORRECT_CASE_FILE:
-                return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(exception.getMessage());
-            default:
-                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        }
+        return switch (exception.getType()) {
+            case REMOTE_ERROR -> ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exception.getMessage());
+            case INCORRECT_CASE_FILE, UNKNOWN_CASE_SOURCE ->
+                    ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(exception.getMessage());
+            default -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        };
     }
 
     @ExceptionHandler(value = {Exception.class})
     protected ResponseEntity<Object> handleAllException(Exception exception) {
-        if (exception instanceof HttpStatusCodeException) {
-            return ResponseEntity.status(((HttpStatusCodeException) exception).getStatusCode()).body(exception.getMessage());
+        if (exception instanceof HttpStatusCodeException httpStatusCodeException) {
+            return ResponseEntity.status(httpStatusCodeException.getStatusCode()).body(exception.getMessage());
         } else {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(exception.getMessage());
         }

--- a/src/main/java/org/gridsuite/caseimport/server/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/org/gridsuite/caseimport/server/RestResponseEntityExceptionHandler.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.client.HttpStatusCodeException;
 
+import java.util.Map;
+
 /**
  * @author Abdelsalem Hedhili <abdelsalem.hedhili at rte-france.com>
  */
@@ -28,9 +30,9 @@ public class RestResponseEntityExceptionHandler {
             LOGGER.error(exception.getMessage(), exception);
         }
         return switch (exception.getType()) {
-            case REMOTE_ERROR -> ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exception.getMessage());
+            case REMOTE_ERROR -> new ResponseEntity<>(Map.of("message", exception.getMessage()), HttpStatus.BAD_REQUEST);
             case INCORRECT_CASE_FILE, UNKNOWN_CASE_SOURCE ->
-                    ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(exception.getMessage());
+                    new ResponseEntity<>(Map.of("message", exception.getMessage()), HttpStatus.UNPROCESSABLE_ENTITY);
             default -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         };
     }

--- a/src/main/java/org/gridsuite/caseimport/server/dto/ImportedCase.java
+++ b/src/main/java/org/gridsuite/caseimport/server/dto/ImportedCase.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package org.gridsuite.caseimport.server;
+package org.gridsuite.caseimport.server.dto;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -2,7 +2,11 @@ spring:
   application:
     name: case-import-server
 
-target-directory-name: Automatic_cases_import
+# mapping of target directories based on the origin of the case
+case-import-server:
+  target-directories:
+    origin1: case_import_directory_1
+    default: Automatic_cases_import
 
 server:
   max-http-header-size: 64000


### PR DESCRIPTION
Allow configuring the target directory of the case importing per case origin.
The case origin is specified as a request parameter caseOrigin. This parameter is optional. When it is not provided, the import uses a default target directory. 
If caseOrigin is wrong, the request fails (422)

This PR includes:
 - removal of dead code in test class
 - replacing getBytes with getResource to avoid loading the whole file in memory
 - the return for the case import API gives a message containing information about the imported case (its id, its parent directory and its name)