### PR TITLE
Fix double encoding of directory path

### DIFF
--- a/src/main/java/org/gridsuite/caseimport/server/DirectoryService.java
+++ b/src/main/java/org/gridsuite/caseimport/server/DirectoryService.java
@@ -51,6 +51,7 @@ public class DirectoryService {
         String path = UriComponentsBuilder
                 .fromPath(ROOT_DIRECTORIES_SERVER_ROOT_PATH + "/paths/elements")
                 .queryParam("directoryPath", directoryName)
+                .build(false) // the encoding is already done in restTemplate.exchange()
                 .toUriString();
         HttpHeaders headers = new HttpHeaders();
         headers.add(HEADER_USER_ID, userId);


### PR DESCRIPTION
There is a double encoding of the directoryPath in the DirectoryService.
The pattern is the following where a first encoding is done in:
```java
        String path = UriComponentsBuilder
                .fromPath([...])
                .queryParam([...])
                .toUriString(); // encoded here
```
And a second one when using ```restTemplate.exchange()```
There are other places in our code where we decode while we should just not encode twice:
https://github.com/gridsuite/loadflow-server/blob/32904c78c88b4fcee92108581acfbab1b9a2d24a/src/main/java/org/gridsuite/loadflow/server/LoadFlowController.java#L85