### PR TITLE
Make case name independent of file name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,10 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-stream</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-commons</artifactId>
+        </dependency>
 
         <!-- Runtime dependencies -->
         <dependency>

--- a/src/main/java/org/gridsuite/caseimport/server/CaseImportController.java
+++ b/src/main/java/org/gridsuite/caseimport/server/CaseImportController.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.NotBlank;
 import org.gridsuite.caseimport.server.dto.ImportedCase;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.HttpStatus;
@@ -19,8 +18,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.Optional;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -46,7 +43,7 @@ public class CaseImportController {
         @ApiResponse(responseCode = "422", description = "File with wrong extension"),
         @ApiResponse(responseCode = "201", description = "Case created successfully")})
     public ResponseEntity<ImportedCase> importCase(@Parameter(description = "case file") @RequestPart("caseFile") MultipartFile caseFile,
-                                                   @Parameter(description = "name of the case") @NotBlank Optional<String> caseName,
+                                                   @Parameter(description = "name of the case") @RequestParam(required = false) String caseName,
                                                    @Parameter(description = "origin of case file") @RequestParam(defaultValue = "default", required = false) String caseFileSource,
                                                    @RequestHeader("userId") String userId) {
         ImportedCase importedCase = caseImportService.importCaseInDirectory(caseFile, caseName, caseFileSource, userId);

--- a/src/main/java/org/gridsuite/caseimport/server/CaseImportController.java
+++ b/src/main/java/org/gridsuite/caseimport/server/CaseImportController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
 import org.gridsuite.caseimport.server.dto.ImportedCase;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.HttpStatus;
@@ -18,6 +19,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Optional;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -36,14 +39,14 @@ public class CaseImportController {
         this.caseImportService = caseImportService;
     }
 
-    @PostMapping(value = "/cases/{caseName}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/cases", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = APPLICATION_JSON_VALUE)
     @Operation(summary = "Import a case in the parametrized directory")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The case is imported"),
         @ApiResponse(responseCode = "400", description = "Invalid case file"),
         @ApiResponse(responseCode = "422", description = "File with wrong extension"),
         @ApiResponse(responseCode = "201", description = "Case created successfully")})
     public ResponseEntity<ImportedCase> importCase(@Parameter(description = "case file") @RequestPart("caseFile") MultipartFile caseFile,
-                                                   @Parameter(description = "name of the case") @PathVariable String caseName,
+                                                   @Parameter(description = "name of the case") @NotBlank Optional<String> caseName,
                                                    @Parameter(description = "origin of case file") @RequestParam(defaultValue = "default", required = false) String caseFileSource,
                                                    @RequestHeader("userId") String userId) {
         ImportedCase importedCase = caseImportService.importCaseInDirectory(caseFile, caseName, caseFileSource, userId);

--- a/src/main/java/org/gridsuite/caseimport/server/CaseImportController.java
+++ b/src/main/java/org/gridsuite/caseimport/server/CaseImportController.java
@@ -36,16 +36,17 @@ public class CaseImportController {
         this.caseImportService = caseImportService;
     }
 
-    @PostMapping(value = "/cases", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/cases/{caseName}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = APPLICATION_JSON_VALUE)
     @Operation(summary = "Import a case in the parametrized directory")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The case is imported"),
         @ApiResponse(responseCode = "400", description = "Invalid case file"),
         @ApiResponse(responseCode = "422", description = "File with wrong extension"),
         @ApiResponse(responseCode = "201", description = "Case created successfully")})
     public ResponseEntity<ImportedCase> importCase(@Parameter(description = "case file") @RequestPart("caseFile") MultipartFile caseFile,
+                                                   @Parameter(description = "name of the case") @PathVariable String caseName,
                                                    @Parameter(description = "origin of case file") @RequestParam(defaultValue = "default", required = false) String caseFileSource,
                                                    @RequestHeader("userId") String userId) {
-        ImportedCase importedCase = caseImportService.importCaseInDirectory(caseFile, caseFileSource, userId);
+        ImportedCase importedCase = caseImportService.importCaseInDirectory(caseFile, caseName, caseFileSource, userId);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(importedCase);
     }

--- a/src/main/java/org/gridsuite/caseimport/server/CaseImportService.java
+++ b/src/main/java/org/gridsuite/caseimport/server/CaseImportService.java
@@ -12,6 +12,7 @@ import org.gridsuite.caseimport.server.dto.ImportedCase;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.gridsuite.caseimport.server.CaseImportException.Type.UNKNOWN_CASE_SOURCE;
@@ -44,9 +45,10 @@ class CaseImportService {
         return targetDirectory;
     }
 
-    ImportedCase importCaseInDirectory(MultipartFile caseFile, String caseName, String caseOrigin, String userId) {
+    ImportedCase importCaseInDirectory(MultipartFile caseFile, Optional<String> caseNameParam, String caseOrigin, String userId) {
         String targetDirectory = getTargetDirectory(caseOrigin);
         UUID caseUuid = caseService.importCase(caseFile);
+        String caseName = caseNameParam.filter(s -> !s.isEmpty()).orElse(caseFile.getOriginalFilename());
         var caseElementAttributes = new ElementAttributes(caseUuid, caseName, CASE, new AccessRightsAttributes(false), userId, 0L, null);
         directoryService.createElementInDirectory(caseElementAttributes, targetDirectory, userId);
         ImportedCase importedCase = new ImportedCase();

--- a/src/main/java/org/gridsuite/caseimport/server/CaseImportService.java
+++ b/src/main/java/org/gridsuite/caseimport/server/CaseImportService.java
@@ -12,7 +12,6 @@ import org.gridsuite.caseimport.server.dto.ImportedCase;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.gridsuite.caseimport.server.CaseImportException.Type.UNKNOWN_CASE_SOURCE;
@@ -45,10 +44,10 @@ class CaseImportService {
         return targetDirectory;
     }
 
-    ImportedCase importCaseInDirectory(MultipartFile caseFile, Optional<String> caseNameParam, String caseOrigin, String userId) {
+    ImportedCase importCaseInDirectory(MultipartFile caseFile, String caseNameParam, String caseOrigin, String userId) {
         String targetDirectory = getTargetDirectory(caseOrigin);
         UUID caseUuid = caseService.importCase(caseFile);
-        String caseName = caseNameParam.filter(s -> !s.isEmpty()).orElse(caseFile.getOriginalFilename());
+        String caseName = caseNameParam == null || caseNameParam.trim().isEmpty() ? caseFile.getOriginalFilename() : caseNameParam;
         var caseElementAttributes = new ElementAttributes(caseUuid, caseName, CASE, new AccessRightsAttributes(false), userId, 0L, null);
         directoryService.createElementInDirectory(caseElementAttributes, targetDirectory, userId);
         ImportedCase importedCase = new ImportedCase();

--- a/src/main/java/org/gridsuite/caseimport/server/CaseImportService.java
+++ b/src/main/java/org/gridsuite/caseimport/server/CaseImportService.java
@@ -44,10 +44,10 @@ class CaseImportService {
         return targetDirectory;
     }
 
-    ImportedCase importCaseInDirectory(MultipartFile caseFile, String caseOrigin, String userId) {
+    ImportedCase importCaseInDirectory(MultipartFile caseFile, String caseName, String caseOrigin, String userId) {
         String targetDirectory = getTargetDirectory(caseOrigin);
         UUID caseUuid = caseService.importCase(caseFile);
-        var caseElementAttributes = new ElementAttributes(caseUuid, caseFile.getOriginalFilename(), CASE, new AccessRightsAttributes(false), userId, 0L, null);
+        var caseElementAttributes = new ElementAttributes(caseUuid, caseName, CASE, new AccessRightsAttributes(false), userId, 0L, null);
         directoryService.createElementInDirectory(caseElementAttributes, targetDirectory, userId);
         ImportedCase importedCase = new ImportedCase();
         importedCase.setCaseName(caseElementAttributes.getElementName());

--- a/src/main/java/org/gridsuite/caseimport/server/CaseImportService.java
+++ b/src/main/java/org/gridsuite/caseimport/server/CaseImportService.java
@@ -6,12 +6,15 @@
  */
 package org.gridsuite.caseimport.server;
 
+import org.apache.commons.lang3.StringUtils;
 import org.gridsuite.caseimport.server.dto.AccessRightsAttributes;
 import org.gridsuite.caseimport.server.dto.ElementAttributes;
 import org.gridsuite.caseimport.server.dto.ImportedCase;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import com.powsybl.commons.datasource.DataSourceUtil;
 
+import java.util.Objects;
 import java.util.UUID;
 
 import static org.gridsuite.caseimport.server.CaseImportException.Type.UNKNOWN_CASE_SOURCE;
@@ -44,11 +47,18 @@ class CaseImportService {
         return targetDirectory;
     }
 
-    ImportedCase importCaseInDirectory(MultipartFile caseFile, String caseNameParam, String caseOrigin, String userId) {
+    ImportedCase importCaseInDirectory(MultipartFile caseFile, String caseName, String caseOrigin, String userId) {
         String targetDirectory = getTargetDirectory(caseOrigin);
         UUID caseUuid = caseService.importCase(caseFile);
-        String caseName = caseNameParam == null || caseNameParam.trim().isEmpty() ? caseFile.getOriginalFilename() : caseNameParam;
-        var caseElementAttributes = new ElementAttributes(caseUuid, caseName, CASE, new AccessRightsAttributes(false), userId, 0L, null);
+        String computedCaseName = StringUtils.isBlank(caseName) ? DataSourceUtil.getBaseName(Objects.requireNonNull(caseFile.getOriginalFilename())) : caseName;
+        var caseElementAttributes = new ElementAttributes(caseUuid,
+                computedCaseName,
+                CASE,
+                new AccessRightsAttributes(false),
+                userId,
+                0L,
+                null);
+
         directoryService.createElementInDirectory(caseElementAttributes, targetDirectory, userId);
         ImportedCase importedCase = new ImportedCase();
         importedCase.setCaseName(caseElementAttributes.getElementName());

--- a/src/test/java/org/gridsuite/caseimport/server/CaseImportTest.java
+++ b/src/test/java/org/gridsuite/caseimport/server/CaseImportTest.java
@@ -38,6 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 public class CaseImportTest {
     private static final String TEST_FILE = "testCase.xiidm";
+    private static final String TEST_CASE_NAME = "testCase";
     private static final String TEST_FILE_WITH_ERRORS = "testCase_with_errors.xiidm";
     private static final String DEFAULT_IMPORT_DIRECTORY = "Automatic_cases_import";
     private static final String INVALID_CASE_ORIGIN = "invalid_source";
@@ -167,7 +168,7 @@ public class CaseImportTest {
                             .param("caseName", "")
                     )
                     .andExpectAll(status().isCreated(),
-                            jsonPath("caseName").value(TEST_FILE),
+                            jsonPath("caseName").value(TEST_CASE_NAME),
                             jsonPath("parentDirectory").value(CASE_ORIGIN_1_DIRECTORY));
         }
 

--- a/src/test/java/org/gridsuite/caseimport/server/CaseImportTest.java
+++ b/src/test/java/org/gridsuite/caseimport/server/CaseImportTest.java
@@ -79,7 +79,7 @@ public class CaseImportTest {
         try (InputStream is = new FileInputStream(ResourceUtils.getFile("classpath:" + TEST_FILE))) {
             MockMultipartFile mockFile = new MockMultipartFile("caseFile", TEST_FILE, "text/xml", is);
 
-            mockMvc.perform(multipart("/v1/cases").file(mockFile)
+            mockMvc.perform(multipart("/v1/cases/testCase").file(mockFile)
                             .header("userId", USER1)
                             .contentType(MediaType.MULTIPART_FORM_DATA)
                     )
@@ -94,7 +94,7 @@ public class CaseImportTest {
         try (InputStream is = new FileInputStream(ResourceUtils.getFile("classpath:" + TEST_FILE))) {
             MockMultipartFile mockFile = new MockMultipartFile("caseFile", TEST_FILE_WITH_ERRORS, "text/xml", is);
 
-            mockMvc.perform(multipart("/v1/cases").file(mockFile)
+            mockMvc.perform(multipart("/v1/cases/testCase_with_errors").file(mockFile)
                             .header("userId", USER1)
                             .contentType(MediaType.MULTIPART_FORM_DATA)
                     )
@@ -109,7 +109,7 @@ public class CaseImportTest {
         try (InputStream is = new FileInputStream(ResourceUtils.getFile("classpath:" + TEST_FILE))) {
             MockMultipartFile mockFile = new MockMultipartFile("caseFile", TEST_INCORRECT_FILE, "text/xml", is);
 
-            mockMvc.perform(multipart("/v1/cases").file(mockFile)
+            mockMvc.perform(multipart("/v1/cases/incorrectFile").file(mockFile)
                             .header("userId", USER1)
                             .contentType(MediaType.MULTIPART_FORM_DATA)
                     )
@@ -124,7 +124,7 @@ public class CaseImportTest {
         try (InputStream is = new FileInputStream(ResourceUtils.getFile("classpath:" + TEST_FILE))) {
             MockMultipartFile mockFile = new MockMultipartFile("caseFile", TEST_FILE, "text/xml", is);
 
-            mockMvc.perform(multipart("/v1/cases").file(mockFile)
+            mockMvc.perform(multipart("/v1/cases/testCase").file(mockFile)
                             .header("userId", USER1)
                             .contentType(MediaType.MULTIPART_FORM_DATA)
                             .param("caseFileSource", INVALID_CASE_ORIGIN)
@@ -140,13 +140,13 @@ public class CaseImportTest {
         try (InputStream is = new FileInputStream(ResourceUtils.getFile("classpath:" + TEST_FILE))) {
             MockMultipartFile mockFile = new MockMultipartFile("caseFile", TEST_FILE, "text/xml", is);
 
-            mockMvc.perform(multipart("/v1/cases").file(mockFile)
+            mockMvc.perform(multipart("/v1/cases/testCase").file(mockFile)
                             .header("userId", USER1)
                             .contentType(MediaType.MULTIPART_FORM_DATA)
                             .param("caseFileSource", CASE_ORIGIN_1)
                     )
                     .andExpectAll(status().isCreated(),
-                            jsonPath("caseName").value(TEST_FILE),
+                            jsonPath("caseName").value("testCase"),
                             jsonPath("parentDirectory").value(CASE_ORIGIN_1_DIRECTORY));
         }
     }

--- a/src/test/java/org/gridsuite/caseimport/server/CaseImportTest.java
+++ b/src/test/java/org/gridsuite/caseimport/server/CaseImportTest.java
@@ -79,7 +79,7 @@ public class CaseImportTest {
         try (InputStream is = new FileInputStream(ResourceUtils.getFile("classpath:" + TEST_FILE))) {
             MockMultipartFile mockFile = new MockMultipartFile("caseFile", TEST_FILE, "text/xml", is);
 
-            mockMvc.perform(multipart("/v1/cases/testCase").file(mockFile)
+            mockMvc.perform(multipart("/v1/cases").file(mockFile)
                             .header("userId", USER1)
                             .contentType(MediaType.MULTIPART_FORM_DATA)
                     )
@@ -94,7 +94,7 @@ public class CaseImportTest {
         try (InputStream is = new FileInputStream(ResourceUtils.getFile("classpath:" + TEST_FILE))) {
             MockMultipartFile mockFile = new MockMultipartFile("caseFile", TEST_FILE_WITH_ERRORS, "text/xml", is);
 
-            mockMvc.perform(multipart("/v1/cases/testCase_with_errors").file(mockFile)
+            mockMvc.perform(multipart("/v1/cases").file(mockFile)
                             .header("userId", USER1)
                             .contentType(MediaType.MULTIPART_FORM_DATA)
                     )
@@ -109,7 +109,7 @@ public class CaseImportTest {
         try (InputStream is = new FileInputStream(ResourceUtils.getFile("classpath:" + TEST_FILE))) {
             MockMultipartFile mockFile = new MockMultipartFile("caseFile", TEST_INCORRECT_FILE, "text/xml", is);
 
-            mockMvc.perform(multipart("/v1/cases/incorrectFile").file(mockFile)
+            mockMvc.perform(multipart("/v1/cases").file(mockFile)
                             .header("userId", USER1)
                             .contentType(MediaType.MULTIPART_FORM_DATA)
                     )
@@ -124,7 +124,7 @@ public class CaseImportTest {
         try (InputStream is = new FileInputStream(ResourceUtils.getFile("classpath:" + TEST_FILE))) {
             MockMultipartFile mockFile = new MockMultipartFile("caseFile", TEST_FILE, "text/xml", is);
 
-            mockMvc.perform(multipart("/v1/cases/testCase").file(mockFile)
+            mockMvc.perform(multipart("/v1/cases").file(mockFile)
                             .header("userId", USER1)
                             .contentType(MediaType.MULTIPART_FORM_DATA)
                             .param("caseFileSource", INVALID_CASE_ORIGIN)
@@ -135,19 +135,41 @@ public class CaseImportTest {
 
     @Test
     public void testImportCaseWithValidOrigin() throws Exception {
+        final String caseName = "testCase";
         wireMockUtils.stubImportCase(TEST_FILE);
         wireMockUtils.stubAddDirectoryElement(CASE_ORIGIN_1_DIRECTORY);
         try (InputStream is = new FileInputStream(ResourceUtils.getFile("classpath:" + TEST_FILE))) {
             MockMultipartFile mockFile = new MockMultipartFile("caseFile", TEST_FILE, "text/xml", is);
 
-            mockMvc.perform(multipart("/v1/cases/testCase").file(mockFile)
+            mockMvc.perform(multipart("/v1/cases").file(mockFile)
                             .header("userId", USER1)
                             .contentType(MediaType.MULTIPART_FORM_DATA)
                             .param("caseFileSource", CASE_ORIGIN_1)
+                            .param("caseName", caseName)
                     )
                     .andExpectAll(status().isCreated(),
-                            jsonPath("caseName").value("testCase"),
+                            jsonPath("caseName").value(caseName),
                             jsonPath("parentDirectory").value(CASE_ORIGIN_1_DIRECTORY));
         }
+    }
+
+    @Test
+    public void testGivenEmptyCaseNameUseFilename() throws Exception {
+        wireMockUtils.stubImportCase(TEST_FILE);
+        wireMockUtils.stubAddDirectoryElement(CASE_ORIGIN_1_DIRECTORY);
+        try (InputStream is = new FileInputStream(ResourceUtils.getFile("classpath:" + TEST_FILE))) {
+            MockMultipartFile mockFile = new MockMultipartFile("caseFile", TEST_FILE, "text/xml", is);
+
+            mockMvc.perform(multipart("/v1/cases").file(mockFile)
+                            .header("userId", USER1)
+                            .contentType(MediaType.MULTIPART_FORM_DATA)
+                            .param("caseFileSource", CASE_ORIGIN_1)
+                            .param("caseName", "")
+                    )
+                    .andExpectAll(status().isCreated(),
+                            jsonPath("caseName").value(TEST_FILE),
+                            jsonPath("parentDirectory").value(CASE_ORIGIN_1_DIRECTORY));
+        }
+
     }
 }


### PR DESCRIPTION
Currently, the case import server uses the filename as the case name. This leads to extensions in case names.
For example: import caseFile.xml.gz will lead to case name caseFile.xml.gz.
The goal is to allow the client to choose a case name different that the file name.